### PR TITLE
Implemented greedy k-nearest neighbour searching (re-commit)

### DIFF
--- a/data_structures/quadtree.cpp
+++ b/data_structures/quadtree.cpp
@@ -1,5 +1,7 @@
 // quadtree.cpp
 
+#include <queue>
+
 #include "quadtree.hpp"
 
 int const MAX_LEAF_SIZE = 8;
@@ -32,7 +34,8 @@ spatial::Range spatial::Quadtree<T>::build(std::vector<T> const raw_data) {
 
 template<typename T>
 spatial::Range spatial::Quadtree<T>::recursive_build(
-        Node* const node, std::vector<Datum<T>> data) {
+    Node* const node, std::vector<Datum<T>> data
+) {
     if (data.size() <= MAX_LEAF_SIZE) {
         // Create a new leaf node
         index_t const index = leaves.size();
@@ -77,131 +80,72 @@ void spatial::Quadtree<T>::recursive_deconstruct(Node* const node) {
 }
 
 /**
- * Query the quadtree for all points "around" a given query point.
- * Currently, this means all points in the query point's leaf, as well as
- * all points in the 8 leaves which border on the query point's leaf.
+ * Query the quadtree for the k-nearest neighbours of a query point.
+ * We do this with a doubly-greedy approach. First, we keep track of a priority
+ * queue of quadtree nodes (initialized with just the root), and repeatedly
+ * expand the node closest to the query point. As we find leaf nodes, we fill
+ * up a second priority queue containing the nearest neighbours so far. Once
+ * we have k points, and our "worst" nearest neighbour is closer than the next 
+ * closest node, we terminate the search and return the k-nearest neighbours.
  */
 template<typename T>
-std::vector<T> spatial::Quadtree<T>::query(coord_t const x, coord_t const y) {
-    Node* const origin_node = find_leaf((Point){x, y});
-    std::vector<code_t> neighbour_codes = calc_neighbour_codes(
-        origin_node->code, origin_node->depth);
+std::vector<T> spatial::Quadtree<T>::query_knn(
+    unsigned const k, coord_t const x, coord_t const y
+) {
+    Point const query_point = {x, y};
 
-    // Start by collecting points from the origin node and its siblings
-    // No traversal needed, since all four are contiguous in the leaf vector
-    std::vector<T> query_bucket;
-    index_t const origin_index = origin_node->leaf_range.start;
-    int const origin_quadrant = origin_node->code & 3;
-    for (int i=(origin_index - origin_quadrant); i<4; i++) {
-        for (auto const& datum : leaves[i].bucket) {
-            query_bucket.push_back(datum.data);
-        }
-    }
-    // Next, collect points from the five non-sibling neighbours
-    // A small optimization here could be to group sibling codes together
-    Node* last_node = NULL;
-    for (auto const target_code : neighbour_codes) {
-        Node* const target_node = traverse(origin_node, target_code);
+    // Set up the node priority queue
+    auto const node_cmp = [](NodePQE a, NodePQE b) {
+        return (a.dist > b.dist);
+    };
+    std::priority_queue<NodePQE, std::vector<NodePQE>, decltype(node_cmp)> 
+        node_pq(node_cmp);
+    node_pq.push((NodePQE){root, distance(query_point, root->bounds)});
 
-        // Ensure we're not querying a node >1 time; this can happen if we
-        // reach a leaf before getting to the target depth
-        if (target_node != last_node) {
-            // Since we keep track of each nodes' contiguous range of leaves
-            // in the leaf vector, collecting points from a leaf is the same
-            // as collecting points from an internal node
-            index_t const start = target_node->leaf_range.start;
-            index_t const end = target_node->leaf_range.end;
-            for (index_t i=start; i<=end; i++) {
-                for (auto const& datum : leaves[i].bucket) {
-                    query_bucket.push_back(datum.data);
+    // Set up the datum priority queue
+    auto const datum_cmp = [](DatumPQE a, DatumPQE b) {
+        return (a.dist < b.dist);
+    };
+    std::priority_queue<DatumPQE, std::vector<DatumPQE>, decltype(datum_cmp)> 
+        datum_pq(datum_cmp);
+
+    // Search the quadtree
+    while (datum_pq.size() < k
+           || datum_pq.top().dist > node_pq.top().dist) {
+        NodePQE const npqe = node_pq.top();
+        node_pq.pop();
+
+        if (npqe.node->is_leaf()) {
+            // Examine the points in the leaf
+            index_t const leaf_index = npqe.node->leaf_range.start;
+            for (auto const& datum : leaves[leaf_index].bucket) {
+                coord_t const new_dist = distance(query_point, datum.point);
+                // We have fewer than k points: take the new point
+                if (datum_pq.size() < k) {
+                    datum_pq.push((DatumPQE){datum, new_dist});
+                }
+                // The new point is better than our worst point: replace it
+                else if (datum_pq.top().dist > new_dist) {
+                    datum_pq.pop();
+                    datum_pq.push((DatumPQE){datum, new_dist});
                 }
             }
-            last_node = target_node;
+        } else {
+            // Expand the node, adding its children to the priority queue
+            for (auto const& child : npqe.node->children) {
+                coord_t const dist = distance(query_point, child->bounds);
+                node_pq.push((NodePQE){child, dist});
+            }
         }
+    }
+    std::vector<T> query_bucket;
+    query_bucket.reserve(k);
+    while (!datum_pq.empty()) {
+        DatumPQE e = datum_pq.top();
+        query_bucket.push_back(e.datum.data);
+        datum_pq.pop();
     }
     return query_bucket;
-}
-
-/**
- * Calculate the neighbouring location codes of a given origin location code.
- * This function uses a finite state machine (defined in the header file) to
- * calculate neighbour codes for each direction. The algorithm is described
- * in detail in by Yoder and Bloniarz (2006).
- */
-template<typename T>
-std::vector<code_t> spatial::Quadtree<T>::calc_neighbour_codes(
-        const code_t origin_code, const int depth) {
-    // Calculate a code for each direction, clockwise starting from north
-    std::vector<code_t> codes;
-    for (int i=0; i<8; i++) {
-        int direction = i; // Initial neighbour direction
-        code_t c0 = origin_code;
-
-        // Calculate each new digit in order (right to left)
-        for (int j=0; j<depth; j++) {
-            code_t const d0 = (origin_code >> (2*j)) & 3; // origin digit j
-            code_t const d1 = fsm[d0][direction][0]; // neighbour digit j
-            code_t const c1 = ~(3 << (2*j)); // bitmask to clear digit j
-
-            c0 &= c1; // Clear the jth digit of the origin code
-            c0 |= (d1 << (2*j)); // Set the jth digit of the new neighbour code
-
-            if (fsm[d0][direction][1] == -1){
-                break; // We've found a sibling -> halt
-            } else {
-                direction = fsm[d0][direction][1]; // Update travel direction
-            }
-            // If we reach the top level of the quadtree without finding
-            // a sibling, then a neighbour doesn't exist in this direction
-            if (j == depth-1) c0 = -1;
-        }
-        // Conditions for filtering out certain types of neighbour codes
-        if (c0 == -1) continue; // Neighbour does not exist
-        if (c0 >> 2 == origin_code >> 2) continue; // Neighbour is a sibling
-
-        codes.push_back(c0);
-    }
-    return codes;
-}
-
-// Traverse the quadtree from an origin node to a target location code.
-template<typename T>
-typename spatial::Quadtree<T>::Node* spatial::Quadtree<T>::traverse(
-        Node* const origin_node, code_t const target_code) {
-    int const origin_depth = origin_node->depth;
-    
-    // Ascend the tree until we find a common ancestor node
-    Node* current_node = origin_node;
-    while (true) {
-        int const depth_difference = origin_depth - current_node->depth;
-        if (current_node->code == target_code >> (2*depth_difference)) {
-            break;
-        } else {
-            current_node = current_node->parent;
-        }
-    }
-
-    // Descend the tree according to the target location code
-    // Note that we might hit a leaf before reaching the target location,
-    // or we might discover that the target is an internal node
-    while (!current_node->is_leaf()) {
-        int const depth_difference = origin_depth - current_node->depth;
-        int const next_quadrant = (target_code >> (2*(depth_difference - 1))) & 3;
-        current_node = current_node->children[next_quadrant];
-    }
-    return current_node;
-}
-
-// Find the leaf whose bounds contain the given point
-template<typename T>
-typename spatial::Quadtree<T>::Node* spatial::Quadtree<T>::find_leaf(const Point p) {
-    Node* current_node = root;
-    int next_quadrant;
-    while (!current_node->is_leaf()) {
-        next_quadrant = get_quadrant(current_node->center, p);
-        current_node = current_node->children[next_quadrant];
-    }
-    return current_node;
 }
 
 /**
@@ -216,6 +160,18 @@ int spatial::Quadtree<T>::get_quadrant(Point origin, Point p) {
 
 template<typename T>
 int spatial::Quadtree<T>::num_leaves() { return leaves.size(); }
+
+/**
+ * Verify that EVERY leaf in the quadtree is at depth k
+ * Note that this will only pass for a complete quadtree of depth k
+ */
+template<typename T>
+bool spatial::Quadtree<T>::check_depth_equals(unsigned const k) {
+    for (auto const& leaf : leaves) {
+        if (leaf.node->depth != k) return false;
+    }
+    return true;
+}
 
 template<typename T>
 void spatial::Quadtree<T>::Node::create_children() {

--- a/data_structures/quadtree.hpp
+++ b/data_structures/quadtree.hpp
@@ -1,12 +1,12 @@
 // quadtree.hpp
 
+#include <cmath>
 #include <array>
 #include <vector>
 
 #pragma once
 
 namespace spatial {
-
     // Type aliases!
     using coord_t = double; // Needs to fit whatever numbers are used for data
     using code_t = long long int; // Needs at least 2*(quadtree height) bits
@@ -20,6 +20,20 @@ namespace spatial {
         coord_t const xmedian = (rect.xmin + rect.xmax) / 2;
         coord_t const ymedian = (rect.ymin + rect.ymax) / 2;
         return {xmedian, ymedian};
+    }
+
+    coord_t distance(Point const p, Point const q) {
+        coord_t const dx = p.x - q.x;
+        coord_t const dy = p.y - q.y;
+        return std::sqrt(dx*dx + dy*dy);
+    }
+
+    coord_t distance(Point const p, Rectangle const rect) {
+        coord_t dx = std::max(rect.xmin - p.x, p.x - rect.xmax);
+        coord_t dy = std::max(rect.ymin - p.y, p.y - rect.ymax);
+        dx = std::max(dx, 0.0);
+        dy = std::max(dy, 0.0);
+        return std::sqrt(dx*dx + dy*dy);
     }
 
     /**
@@ -54,6 +68,18 @@ namespace spatial {
                 Node* node;
                 std::vector<Datum<T>> bucket;
             };
+
+            // Node Priority Queue Element
+            struct NodePQE {
+                Node* node;
+                coord_t dist;
+            };
+
+            // Datum Priority Queue Element
+            struct DatumPQE {
+                Datum<T> datum;
+                coord_t dist;
+            };
             
             Node* root;
             std::vector<Leaf> leaves;
@@ -61,32 +87,13 @@ namespace spatial {
             Range recursive_build(Node* const node, std::vector<Datum<T>> data);
             void recursive_deconstruct(Node* const node);
             int get_quadrant(Point const origin, Point const p);
-            Node* find_leaf(Point const p);
-            Node* traverse(Node* const origin_node, code_t const target_code);
-            std::vector<code_t> calc_neighbour_codes(
-                code_t const origin_code, int const depth);
 
         public:
             Quadtree(coord_t x0, coord_t x1, coord_t y0, coord_t y1);
             ~Quadtree();
             Range build(std::vector<T> const raw_data);
-            std::vector<T> query(coord_t const x, coord_t const y);
+            std::vector<T> query_knn(unsigned const k, coord_t const x, coord_t const y);
             int num_leaves();
-
-            /**
-             * A lightweight finite state machine for computing neighbour codes
-             * First dimension is a 2-bit code digit (0-3)
-             * Second dimension is the direction (N, NE, E, SE, S, SW, W, NW)
-             * The third dimension is a <digit, halt?> pair: "digit" is the new
-             * code digit after traveling in the given direction, and "halt?"
-             * is either a signal to stop the calculation because we're at a
-             * sibling (-1), or the new travel direction (0-7).
-             */
-            int const fsm[4][8][2] = {
-                {{2,0}, {3,0}, {1,-1}, {3,-1}, {2,-1}, {3,6}, {1,6}, {3,7}},
-                {{3,0}, {2,1}, {0,2}, {2,2}, {3,-1}, {2,-1}, {0,-1}, {2,0}},
-                {{0,-1}, {1,-1}, {3,-1}, {1,4}, {0,4}, {1,5}, {3,6}, {1,6}},
-                {{1,-1}, {0,2}, {2,2}, {0,3}, {1,4}, {0,4}, {2,-1}, {0,-1}}
-            };
+            bool check_depth_equals(unsigned const k);
     }; 
 }


### PR DESCRIPTION
Greedy distance browsing ended up not being as much work to implement as I expected!

Some small optimizations could probably be made by building a custom priority queue from scratch, but the built-in one is a quick and easy solution for now.

I've just finished a testing wrapper (using catch2) for the correctness of the quadtree and its k-nn queries, and I'm about to start building some timing tests. I'll save these for another pull request, though.