### PR TITLE
R-tree push #1

### DIFF
--- a/data_structures/quadtree.hpp
+++ b/data_structures/quadtree.hpp
@@ -1,50 +1,13 @@
 // quadtree.hpp
 
-#include <cmath>
 #include <array>
 #include <vector>
+
+#include "spatial.hpp"
 
 #pragma once
 
 namespace spatial {
-    // Type aliases!
-    using coord_t = double; // Needs to fit whatever numbers are used for data
-    using code_t = long long int; // Needs at least 2*(quadtree height) bits
-    using index_t = unsigned long int; // Needs to fit the total # of leaves
- 
-    struct Range { index_t start, end; };
-    struct Rectangle { coord_t xmin, xmax, ymin, ymax; };
-    struct Point { coord_t x, y; };
-
-    Point midpoint(Rectangle const rect) {
-        coord_t const xmedian = (rect.xmin + rect.xmax) / 2;
-        coord_t const ymedian = (rect.ymin + rect.ymax) / 2;
-        return {xmedian, ymedian};
-    }
-
-    coord_t distance(Point const p, Point const q) {
-        coord_t const dx = p.x - q.x;
-        coord_t const dy = p.y - q.y;
-        return std::sqrt(dx*dx + dy*dy);
-    }
-
-    coord_t distance(Point const p, Rectangle const rect) {
-        coord_t dx = std::max(rect.xmin - p.x, p.x - rect.xmax);
-        coord_t dy = std::max(rect.ymin - p.y, p.y - rect.ymax);
-        dx = std::max(dx, 0.0);
-        dy = std::max(dy, 0.0);
-        return std::sqrt(dx*dx + dy*dy);
-    }
-
-    /**
-     * A "datum" is a single element in the quadtree. Contains the raw data,
-     * as well as a 2d interpretation of that data as a "point".
-     */
-    template<typename T>
-    struct Datum {
-        T data;
-        Point point;
-    };
 
     template<typename T>
     class Quadtree {

--- a/data_structures/rtree.cpp
+++ b/data_structures/rtree.cpp
@@ -1,0 +1,168 @@
+// rtree.cpp
+
+#include <iostream>
+#include <memory>
+
+#include "rtree.hpp"
+
+using coord_t = spatial::coord_t;
+using code_t = spatial::code_t;
+using index_t = spatial::index_t;
+
+int const M = 8;
+
+template<typename T>
+spatial::Rtree<T>::Rtree(): 
+    root_entry(std::make_shared<InternalEntry>()) 
+{
+    root_entry->bounding_box = (Rectangle){0, 0, 0, 0};
+    root_entry->node = std::make_shared<Node>(*this);
+}
+
+// ~Rtree() {}
+
+template<typename T>
+spatial::Rtree<T>::Node::Node(Rtree& rt): 
+    load(0), 
+    m(0), 
+    rtree(rt) 
+{ }
+
+// ~Node() {}
+
+/**
+ * Construct an R-tree from the given point data.
+ * Currently, this is just doing point-by-point insertion
+ */
+template<typename T>
+void spatial::Rtree<T>::build(std::vector<T> const raw_data) {
+    // Pick an inital bounding box for the root
+    Rectangle initial_seed = {
+        raw_data[0][0], raw_data[0][0],
+        raw_data[0][1], raw_data[0][1]
+    };
+    root_entry->bounding_box = initial_seed;
+
+    // Insert each data point into the R-tree
+    data.reserve(raw_data.size());
+    for (auto const& raw_datum : raw_data) {
+        Point const new_point = {raw_datum[0], raw_datum[1]};
+        Datum<T> const new_datum = {raw_datum, new_point};
+        insert(new_datum);
+    } 
+}
+
+template<typename T>
+void spatial::Rtree<T>::insert(Datum<T> new_datum) {
+    data.push_back(new_datum);
+
+    // Expand the root's bounding box if necessary
+    root_entry->bounding_box = min_bounding_box(
+        root_entry->bounding_box, new_datum.point
+    );
+
+    // Recursively insert the point into the root node
+    if (root_entry->node->insert(data.size()-1)) {
+        split_root();
+    }
+}
+
+/**
+ * Recursively insert a point into the current node.
+ * If a node exceeds M entries, we return 'true' to indicate that a split
+ * is required, since splitting happens at the parent's level.  
+ */
+template<typename T>
+bool spatial::Rtree<T>::Node::insert(index_t const point_idx) {
+    Point const p = rtree.data[point_idx].point;
+    if (this->is_leaf()) {
+        // add the point to the current node
+        auto new_entry = std::make_shared<LeafEntry>();
+        new_entry->bounding_box = (Rectangle){ p.x, p.x, p.y, p.y };
+        new_entry->idx = point_idx;
+        entries.push_back(new_entry);
+        m++;
+    } else {
+        // we're in an internal node, and need to descend further
+        int const branch_idx = choose_branch(p);
+        auto entry = std::dynamic_pointer_cast<InternalEntry>(
+            entries[branch_idx]
+        );
+
+        // expand the child's bounding box as needed
+        entry->bounding_box = min_bounding_box(
+            entry->bounding_box, p
+        );
+
+        // recurse on the child node
+        if (entry->node->insert(point_idx)) {
+            split(branch_idx);  // split if the child overflows
+        } 
+    }
+    load++;
+    return (m > M);  // if (m > M), this branch needs to be split
+}
+
+/**
+ * Split an overflowing entry (aka child node) into two new entries.
+ * Note that the object we're calling split() on is the PARENT of the node
+ * to be split, not the node itself.
+ */
+template<typename T>
+void spatial::Rtree<T>::Node::split(int const branch_idx) {
+    // pop the overflowing branch from the 'entries' vector
+
+    // pick some seed entries using the split heuristic
+
+    // push the newly seeded branches onto 'entries'
+
+    // distribute the leftover points
+}
+
+/**
+ * When the root node overflows, we need some special logic, 
+ * since it has no parent node.
+ */
+template<typename T>
+void spatial::Rtree<T>::split_root() {
+    // make a new root, with the old root being its only entry
+
+    // root->split(0);
+}
+
+/**
+ * Pick an appropriate child node for a point.
+ * Specifically, we pick the bounding box which requires the
+ * smallest (area) expansion to accommodate the new point.
+ */
+template<typename T>
+int spatial::Rtree<T>::Node::choose_branch(Point const p) const {
+    coord_t min_expansion;
+    int best_choice = -1;
+    int pos = 0;
+    for (auto& entry : entries) {
+        Rectangle const expanded_bb = min_bounding_box(
+            entry->bounding_box, p
+        );
+        coord_t const current_expansion = (
+            area(expanded_bb) - area(entry->bounding_box)
+        );
+        if (best_choice == -1 || current_expansion < min_expansion) {
+            min_expansion = current_expansion;
+            best_choice = pos;
+        }
+        if (min_expansion == 0) break; // We've found the best case
+        pos++;
+    } 
+    return best_choice;
+}
+
+template<typename T>
+spatial::index_t spatial::Rtree<T>::get_load() const { 
+    return root_entry->node->load; 
+}
+
+template<typename T>
+bool spatial::Rtree<T>::Node::is_leaf() const { 
+    return load < M; 
+}

--- a/data_structures/rtree.hpp
+++ b/data_structures/rtree.hpp
@@ -1,0 +1,59 @@
+// rtree.hpp
+
+#include <memory>
+#include <vector>
+
+#include "spatial.hpp" 
+
+#pragma once
+
+namespace spatial {
+
+    template<typename T>
+    class Rtree {
+        private:
+            struct Entry;
+            struct LeafEntry;
+            struct InternalEntry;
+
+            class Node{
+                public:
+                    index_t load;  // # of POINTS in the node + all subnodes
+                    int m;  // # of ENTRIES in the current node
+                    std::vector<std::shared_ptr<Entry>> entries;
+
+                    // Is there a better way to access Rtree class members?
+                    Rtree& rtree;
+
+                    Node(Rtree& rt);
+                    // ~Node();
+                    bool insert(index_t point_idx);
+                    void split(int const branch_idx);
+                    int choose_branch(Point const p) const;
+                    bool is_leaf() const;
+            };
+
+            // Polymorphism to deal with the two types of tree entries
+            struct Entry { 
+                Rectangle bounding_box; 
+                virtual ~Entry() { }
+            };
+            struct LeafEntry : Entry { index_t idx; };
+            struct InternalEntry : Entry { std::shared_ptr<Node> node; };
+
+            std::shared_ptr<InternalEntry> root_entry;
+            std::vector<Datum<T>> data;
+
+            void split_root();
+
+        public:
+            Rtree();
+            // ~Rtree();
+            void build(std::vector<T> const raw_data);
+            void insert(Datum<T> new_datum);
+            std::vector<T> query_knn(
+                unsigned const k, coord_t const x, coord_t const y
+            ) const;
+            index_t get_load() const;
+    };
+}

--- a/data_structures/spatial.hpp
+++ b/data_structures/spatial.hpp
@@ -1,0 +1,81 @@
+// spatial.hpp
+/**
+ * A header file containing some simple 2d structures and functions
+ */
+
+#include <cmath>
+
+#pragma once
+
+namespace spatial {
+
+    // Type aliases!
+    using coord_t = double; // Needs to fit whatever numbers are used for data
+    using code_t = long long int; // Needs at least 2*(quadtree height) bits
+    using index_t = unsigned long int; // Needs to fit the total # of leaves
+ 
+    struct Range { index_t start, end; };
+    struct Rectangle { coord_t xmin, xmax, ymin, ymax; };
+    struct Point { coord_t x, y; };
+
+    Point midpoint(Rectangle const rect) {
+        coord_t const xmedian = (rect.xmin + rect.xmax) / 2;
+        coord_t const ymedian = (rect.ymin + rect.ymax) / 2;
+        return {xmedian, ymedian};
+    }
+
+    coord_t distance(Point const p, Point const q) {
+        coord_t const dx = p.x - q.x;
+        coord_t const dy = p.y - q.y;
+        return std::sqrt(dx*dx + dy*dy);
+    }
+
+    coord_t distance(Point const p, Rectangle const rect) {
+        coord_t dx = std::max(rect.xmin - p.x, p.x - rect.xmax);
+        coord_t dy = std::max(rect.ymin - p.y, p.y - rect.ymax);
+        dx = std::max(dx, 0.0);
+        dy = std::max(dy, 0.0);
+        return std::sqrt(dx*dx + dy*dy);
+    }
+
+    coord_t area(Rectangle const rect) {
+        return (rect.xmax - rect.xmin)*(rect.ymax - rect.ymin);
+    }
+
+    /**
+     * Calculate the minimum bounding box of a rectangle and a point.
+     */
+    Rectangle min_bounding_box(Rectangle const rect, Point const p) {
+        Rectangle mbb = {
+            std::min(rect.xmin, p.x),
+            std::max(rect.xmax, p.x),
+            std::min(rect.ymin, p.y),
+            std::max(rect.ymax, p.y)
+        };
+        return mbb;
+    }
+
+    /**
+     * Calculate the minimum bounding box of two rectangles.
+     */
+    Rectangle min_bounding_box(Rectangle const r1, Rectangle const r2) {
+        Rectangle mbb = {
+            std::min(r1.xmin, r2.xmin),
+            std::max(r1.xmax, r2.xmax),
+            std::min(r1.ymin, r2.ymin),
+            std::max(r1.ymax, r2.ymax)
+        };
+        return mbb;
+    }    
+
+    /**
+     * A single element in a 2d space partitioning tree.
+     * Contains raw data, and an interpetation of that data as a 2d point.
+     */
+    template<typename T>
+    struct Datum {
+        T data;
+        Point point;
+    };
+
+}


### PR DESCRIPTION
This isn't as much code as it looks like! I moved all the generic spatial stuff into its own header file, so that's mostly recycled code from the quadtree implementation.

I'm using a polymorphic 'Entry' struct to handle the two different types of entries in the R-tree, so splits should work the same for internal and leaf nodes. I'm hoping this'll make things easier for passing in splitting heuristics as arguments, if we do end up doing that.
