### PR TITLE
Implemented node splitting to complete the R-tree construction

### DIFF
--- a/data_structures/rtree.cpp
+++ b/data_structures/rtree.cpp
@@ -6,42 +6,42 @@
 #include "rtree.hpp"
 
 using coord_t = spatial::coord_t;
-using code_t = spatial::code_t;
+using area_t = spatial::area_t;
 using index_t = spatial::index_t;
 
 int const M = 8;
 
 template<typename T>
-spatial::Rtree<T>::Rtree(): 
-    root_entry(std::make_shared<InternalEntry>()) 
-{
-    root_entry->bounding_box = (Rectangle){0, 0, 0, 0};
-    root_entry->node = std::make_shared<Node>(*this);
-}
-
-// ~Rtree() {}
-
-template<typename T>
-spatial::Rtree<T>::Node::Node(Rtree& rt): 
-    load(0), 
-    m(0), 
-    rtree(rt) 
+spatial::Rtree<T>::Rtree():
+    root_entry(std::make_unique<Entry>(
+        (Rectangle){0,0,0,0}, 
+        std::make_shared<Node>()
+    ))
 { }
 
-// ~Node() {}
+template<typename T>
+spatial::Rtree<T>::~Rtree() { }
+
+template<typename T>
+spatial::Rtree<T>::Node::Node(): 
+    load(0)
+{ }
+
+template<typename T>
+spatial::Rtree<T>::Node::~Node() { }
 
 /**
  * Construct an R-tree from the given point data.
  * Currently, this is just doing point-by-point insertion
  */
 template<typename T>
-void spatial::Rtree<T>::build(std::vector<T> const raw_data) {
+void spatial::Rtree<T>::build(std::vector<T> const& raw_data) {
     // Pick an inital bounding box for the root
     Rectangle initial_seed = {
         raw_data[0][0], raw_data[0][0],
         raw_data[0][1], raw_data[0][1]
     };
-    root_entry->bounding_box = initial_seed;
+    root_entry->set_mbb(initial_seed);
 
     // Insert each data point into the R-tree
     data.reserve(raw_data.size());
@@ -53,17 +53,17 @@ void spatial::Rtree<T>::build(std::vector<T> const raw_data) {
 }
 
 template<typename T>
-void spatial::Rtree<T>::insert(Datum<T> new_datum) {
+void spatial::Rtree<T>::insert(Datum<T> const& new_datum) {
     data.push_back(new_datum);
 
     // Expand the root's bounding box if necessary
-    root_entry->bounding_box = min_bounding_box(
-        root_entry->bounding_box, new_datum.point
-    );
+    root_entry->set_mbb(min_bounding_box(
+        root_entry->get_mbb(), new_datum.point
+    ));
 
     // Recursively insert the point into the root node
-    if (root_entry->node->insert(data.size()-1)) {
-        split_root();
+    if (root_entry->get_node()->insert(data.back())) {
+        split_root();  // split the root if it overflows
     }
 }
 
@@ -73,34 +73,50 @@ void spatial::Rtree<T>::insert(Datum<T> new_datum) {
  * is required, since splitting happens at the parent's level.  
  */
 template<typename T>
-bool spatial::Rtree<T>::Node::insert(index_t const point_idx) {
-    Point const p = rtree.data[point_idx].point;
+bool spatial::Rtree<T>::Node::insert(Datum<T> const& datum) {
+    Point const p = datum.point;
     if (this->is_leaf()) {
         // add the point to the current node
-        auto new_entry = std::make_shared<LeafEntry>();
-        new_entry->bounding_box = (Rectangle){ p.x, p.x, p.y, p.y };
-        new_entry->idx = point_idx;
-        entries.push_back(new_entry);
-        m++;
+        entries.push_back(Entry(
+            (Rectangle){p.x, p.x, p.y, p.y},
+            std::make_shared<Datum<T>>(datum)
+        ));
     } else {
         // we're in an internal node, and need to descend further
         int const branch_idx = choose_branch(p);
-        auto entry = std::dynamic_pointer_cast<InternalEntry>(
-            entries[branch_idx]
-        );
+        Entry child_entry = entries[branch_idx];
 
         // expand the child's bounding box as needed
-        entry->bounding_box = min_bounding_box(
-            entry->bounding_box, p
-        );
+        child_entry.set_mbb(min_bounding_box(
+            child_entry.get_mbb(), p
+        ));
 
         // recurse on the child node
-        if (entry->node->insert(point_idx)) {
+        if (child_entry.get_node()->insert(datum)) {
             split(branch_idx);  // split if the child overflows
         } 
     }
     load++;
-    return (m > M);  // if (m > M), this branch needs to be split
+    return (entries.size() > M);  // check for node overflow
+}
+
+/**
+ * When the root node overflows, we need some special logic, 
+ * since it has no parent node.
+ */
+template<typename T>
+void spatial::Rtree<T>::split_root() {
+    // make a new root, with the old root being its only entry
+    auto other_entry = std::make_unique<Entry>(
+        root_entry->get_mbb(),
+        std::make_shared<Node>()
+    );
+    root_entry.swap(other_entry);
+    // other_entry now contains the OLD root entry
+    root_entry->get_node()->entries.push_back(*other_entry);
+    root_entry->get_node()->load = other_entry->get_node()->load;
+    // root node entries[0] is now the old, overflowing root
+    root_entry->get_node()->split(0);
 }
 
 /**
@@ -111,23 +127,131 @@ bool spatial::Rtree<T>::Node::insert(index_t const point_idx) {
 template<typename T>
 void spatial::Rtree<T>::Node::split(int const branch_idx) {
     // pop the overflowing branch from the 'entries' vector
+    auto const overflowing_node = entries[branch_idx].get_node();
+    entries.erase(entries.begin() + branch_idx);
 
-    // pick some seed entries using the split heuristic
+    // make some seed entries using the split heuristic
+    pick_seeds(overflowing_node->entries);
 
-    // push the newly seeded branches onto 'entries'
-
-    // distribute the leftover points
+    // distribute the leftover child entries between the seeds
+    distribute(overflowing_node->entries);
 }
 
 /**
- * When the root node overflows, we need some special logic, 
- * since it has no parent node.
+ * Pick a number of "good" seed MBBs from the given choices.
+ * Currently, this function uses the quadratic split heuristic.
  */
 template<typename T>
-void spatial::Rtree<T>::split_root() {
-    // make a new root, with the old root being its only entry
+void spatial::Rtree<T>::Node::pick_seeds(
+    std::vector<Entry> const& entry_choices
+) {
+    unsigned best_e1 = -1, best_e2 = -1;
+    area_t max_d = -1;
+    for (unsigned i=0; i<entry_choices.size(); i++) {
+        Entry const e1 = entry_choices[i];
+        for (unsigned j=i+1; j<entry_choices.size(); j++) {
+            Entry const e2 = entry_choices[j];
+            Rectangle const r = min_bounding_box(e1.get_mbb(), e2.get_mbb());
+            area_t const d = area(r) - area(e1.get_mbb()) - area(e2.get_mbb());
+            if (d > max_d) {
+                max_d = d;
+                best_e1 = i;
+                best_e2 = j;
+            }
+        }
+    }
+    // create two new entries corresponding to the above seed MBBs
+    entries.push_back(Entry(
+        entry_choices[best_e1].get_mbb(),
+        std::make_shared<Node>()
+    ));
+    entries.push_back(Entry(
+        entry_choices[best_e2].get_mbb(),
+        std::make_shared<Node>()
+    ));
+}
 
-    // root->split(0);
+/**
+ * Distribute leftover entries after splitting an overflowing node.
+ * This function is a bit of a mouthful, particularly the if/else stack
+ * at the end, so it could probably do with some revisiting.
+ */
+template<typename T>
+void spatial::Rtree<T>::Node::distribute(
+    std::vector<Entry>& leftover_entries
+) {
+    // our two "groups" are the child nodes that were just created
+    Entry& g1 = entries[entries.size()-1];
+    Entry& g2 = entries[entries.size()-2];
+    while (!leftover_entries.empty()) {
+        // pop the "best" entry from the leftovers vector
+        int const next_idx = pick_next(leftover_entries);
+        Entry const next_entry = leftover_entries[next_idx];
+        leftover_entries.erase(leftover_entries.begin() + next_idx);
+
+        // calculate the MBB expansion needed by each group
+        Rectangle const g1_expanded_mbb = min_bounding_box(
+            g1.get_mbb(), next_entry.get_mbb()
+        );
+        Rectangle const g2_expanded_mbb = min_bounding_box(
+            g2.get_mbb(), next_entry.get_mbb()
+        );
+
+        area_t const g1_expansion = area(g1_expanded_mbb) - area(g1.get_mbb());
+        area_t const g2_expansion = area(g2_expanded_mbb) - area(g2.get_mbb());
+
+        // choose the group which requires the least expansion
+        if (g1_expansion < g2_expansion) {
+            g1.set_mbb(g1_expanded_mbb);
+            g1.get_node()->entries.push_back(next_entry);
+            g1.get_node()->load++;
+        } else if (g1_expansion == g2_expansion) {
+            // break the tie (pick the group w/ the smallest MBB)
+            if (area(g1.get_mbb()) < area(g2.get_mbb())) {
+                g1.set_mbb(g1_expanded_mbb);
+                g1.get_node()->entries.push_back(next_entry);
+                g1.get_node()->load++;
+            } else {
+                g2.set_mbb(g2_expanded_mbb);
+                g2.get_node()->entries.push_back(next_entry);
+                g2.get_node()->load++;
+            }
+        } else {
+            g2.set_mbb(g2_expanded_mbb);
+            g2.get_node()->entries.push_back(next_entry);
+            g2.get_node()->load++;
+        }
+    }
+}
+
+/**
+ * Pick the "best" leftover entry to distribute next.
+ */
+template<typename T>
+int spatial::Rtree<T>::Node::pick_next(
+    std::vector<Entry> const& leftover_entries
+) const {
+    Entry const& g1 = entries[entries.size()-1];
+    Entry const& g2 = entries[entries.size()-2];
+
+    area_t max_diff = 0;
+    int pos = 0, best_choice = 0;
+    for (auto const& entry : leftover_entries) {
+        area_t const d1 = area(
+            min_bounding_box(g1.get_mbb(), entry.get_mbb())      
+        ) - area(g1.get_mbb());
+
+        area_t const d2 = area(
+            min_bounding_box(g2.get_mbb(), entry.get_mbb())      
+        ) - area(g2.get_mbb());
+
+        if (std::abs(d1 - d2) > max_diff) {
+            max_diff = std::abs(d1 - d2);
+            best_choice = pos;
+        }
+        pos++;
+    }
+    return best_choice;
 }
 
 /**
@@ -137,21 +261,26 @@ void spatial::Rtree<T>::split_root() {
  */
 template<typename T>
 int spatial::Rtree<T>::Node::choose_branch(Point const p) const {
-    coord_t min_expansion;
-    int best_choice = -1;
-    int pos = 0;
-    for (auto& entry : entries) {
+    area_t min_expansion = -1;
+    int pos = 0, best_choice = -1;
+    for (auto const& entry : entries) {
         Rectangle const expanded_bb = min_bounding_box(
-            entry->bounding_box, p
+            entry.get_mbb(), p
         );
         coord_t const current_expansion = (
-            area(expanded_bb) - area(entry->bounding_box)
+            area(expanded_bb) - area(entry.get_mbb())
         );
         if (best_choice == -1 || current_expansion < min_expansion) {
             min_expansion = current_expansion;
             best_choice = pos;
+        } 
+        else if (current_expansion == min_expansion) {
+            // break the tie (choose the MBB w/ the smallest area)
+            if (area(entry.get_mbb()) < area(entries[best_choice].get_mbb())) {
+                min_expansion = current_expansion;
+                best_choice = pos;
+            }
         }
-        if (min_expansion == 0) break; // We've found the best case
         pos++;
     } 
     return best_choice;
@@ -159,10 +288,10 @@ int spatial::Rtree<T>::Node::choose_branch(Point const p) const {
 
 template<typename T>
 spatial::index_t spatial::Rtree<T>::get_load() const { 
-    return root_entry->node->load; 
+    return root_entry->get_node()->load; 
 }
 
 template<typename T>
 bool spatial::Rtree<T>::Node::is_leaf() const { 
-    return load < M; 
+    return (entries.size() == load);
 }

--- a/data_structures/rtree.hpp
+++ b/data_structures/rtree.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <vector>
+#include <variant>
 
 #include "spatial.hpp" 
 
@@ -12,45 +13,77 @@ namespace spatial {
     template<typename T>
     class Rtree {
         private:
-            struct Entry;
-            struct LeafEntry;
-            struct InternalEntry;
+            class Entry;
 
-            class Node{
+            class Node {
                 public:
-                    index_t load;  // # of POINTS in the node + all subnodes
-                    int m;  // # of ENTRIES in the current node
-                    std::vector<std::shared_ptr<Entry>> entries;
+                    index_t load;
+                    std::vector<Entry> entries;
 
-                    // Is there a better way to access Rtree class members?
-                    Rtree& rtree;
-
-                    Node(Rtree& rt);
-                    // ~Node();
-                    bool insert(index_t point_idx);
+                    Node();
+                    ~Node();
+                    bool insert(Datum<T> const& datum);
                     void split(int const branch_idx);
                     int choose_branch(Point const p) const;
+                    void pick_seeds(std::vector<Entry> const& entry_choices);
+                    void distribute(std::vector<Entry>& leftovers);
+                    int pick_next(std::vector<Entry> const& leftovers) const;
                     bool is_leaf() const;
             };
 
-            // Polymorphism to deal with the two types of tree entries
-            struct Entry { 
-                Rectangle bounding_box; 
-                virtual ~Entry() { }
-            };
-            struct LeafEntry : Entry { index_t idx; };
-            struct InternalEntry : Entry { std::shared_ptr<Node> node; };
+            /**
+             * For the sake of abstraction from the std::variant polymorphism,
+             * we're keeping the member variables private, at the cost of using
+             * shared_ptr rather than unique_ptr for the std::variant contents.
+             */
+            class Entry {
+                private:
+                    Rectangle _bounding_box;
+                    std::variant<
+                        std::shared_ptr<Datum<T>>, 
+                        std::shared_ptr<Node>
+                    > _contents;
 
-            std::shared_ptr<InternalEntry> root_entry;
+                public:
+                    Entry(Rectangle rect, std::shared_ptr<Datum<T>> datum): 
+                        _bounding_box(rect),
+                        _contents(datum)
+                    { }
+
+                    Entry(Rectangle rect, std::shared_ptr<Node> node): 
+                        _bounding_box(rect),
+                        _contents(node)
+                    { }
+
+                    Rectangle get_mbb() const { return _bounding_box; }
+
+                    void set_mbb(Rectangle const rect) { 
+                        _bounding_box = rect; 
+                    }
+
+                    std::shared_ptr<Datum<T>> get_datum() const { 
+                        return std::get<std::shared_ptr<Datum<T>>>(
+                            _contents
+                        ); 
+                    }
+
+                    std::shared_ptr<Node> get_node() const { 
+                        return std::get<std::shared_ptr<Node>>(
+                            _contents
+                        ); 
+                    }
+            };
+
+            std::unique_ptr<Entry> root_entry;
             std::vector<Datum<T>> data;
 
             void split_root();
 
         public:
             Rtree();
-            // ~Rtree();
-            void build(std::vector<T> const raw_data);
-            void insert(Datum<T> new_datum);
+            ~Rtree();
+            void build(std::vector<T> const& raw_data);
+            void insert(Datum<T> const& new_datum);
             std::vector<T> query_knn(
                 unsigned const k, coord_t const x, coord_t const y
             ) const;

--- a/data_structures/spatial.hpp
+++ b/data_structures/spatial.hpp
@@ -10,9 +10,10 @@
 namespace spatial {
 
     // Type aliases!
-    using coord_t = double; // Needs to fit whatever numbers are used for data
-    using code_t = long long int; // Needs at least 2*(quadtree height) bits
-    using index_t = unsigned long int; // Needs to fit the total # of leaves
+    using coord_t = double;  // Needs to fit whatever numbers are used for data
+    using area_t = coord_t;  // Better semantics for area calculations
+    using code_t = long long int;  // Needs at least 2*(quadtree height) bits
+    using index_t = unsigned long int;  // Needs to fit the total # of leaves
  
     struct Range { index_t start, end; };
     struct Rectangle { coord_t xmin, xmax, ymin, ymax; };
@@ -38,7 +39,7 @@ namespace spatial {
         return std::sqrt(dx*dx + dy*dy);
     }
 
-    coord_t area(Rectangle const rect) {
+    area_t area(Rectangle const rect) {
         return (rect.xmax - rect.xmin)*(rect.ymax - rect.ymin);
     }
 
@@ -66,7 +67,15 @@ namespace spatial {
             std::max(r1.ymax, r2.ymax)
         };
         return mbb;
-    }    
+    }
+
+    void print_rect(Rectangle const rect) {
+        std::cout << std::fixed << std::setprecision(2) 
+                  << "x[" << rect.xmin << ", " << rect.xmax << "]  ";
+
+        std::cout << std::fixed << std::setprecision(2) 
+                  << "y[" << rect.ymin << ", " << rect.ymax << "]\n";
+    }
 
     /**
      * A single element in a 2d space partitioning tree.


### PR DESCRIPTION
Lots of small changes just as a result of implementing `Entry` with a `std::variant` rather than a polymorphic pointer, but the most relevant stuff is happening in `split()` and the functions it calls. I tried to use the same notation for the quadratic splitting functions as in the R*-tree paper (http://www.cs.ucr.edu/~ravi/CS236Papers/rstar.pdf) rather than Guttman's original paper, just because the former is a little more simple and concise.

I've only done a little bit of testing, but construction seems to be working as it should. One caveat is that my memory debugger seems to think there's a very small possible leak happening somewhere, which is strange given that I'm only using smart pointers. I'll plan to revisit this after I do some more in-depth testing, after we've got a query operation.

Also, the issue I was having with the `std::variant` was definitely a result of passing `unique_ptr`s around, so thanks for the guidance on that!