### PR TITLE
Implemented k-nn querying

### DIFF
--- a/data_structures/rtree.hpp
+++ b/data_structures/rtree.hpp
@@ -63,32 +63,15 @@ namespace spatial {
                     }
 
                     std::shared_ptr<Datum<T>> get_datum() const { 
-                        try {
-                            return std::get<std::shared_ptr<Datum<T>>>(
-                                _contents
-                            ); 
-                        } catch (...) {
-                            std::cout << "Bad polymorphism 1. oof.\n";
-
-                            print_rect(this->get_mbb());
-                            std::cout << this->get_node()->load << ", ";
-                            std::cout << this->get_node()->entries.size() << "\n";
-
-                            exit(0);
-                        }
-
-                    }
+                        return std::get<std::shared_ptr<Datum<T>>>(
+                            _contents
+                        );
+                }
 
                     std::shared_ptr<Node> get_node() const { 
-                        try {
-                            return std::get<std::shared_ptr<Node>>(
-                                _contents
-                            ); 
-                        } catch (...) {
-                            std::cout << "Bad polymorphism 2. oof.\n";
-                            exit(0);
-                        }
-                        
+                        return std::get<std::shared_ptr<Node>>(
+                            _contents
+                        );
                     }
 
                     bool is_leaf_entry() const {


### PR DESCRIPTION
I tried to simplify the querying function (compared to in the quadtree implementation) by using a couple of classes as thin layers over top of a `std::priority_queue`. I'm unsure if it's a good idea to put this much implementation code in the header file though.

There were also a couple issues I found with `Node::is_leaf()` in rare edge cases, which I think I've fixed. `is_leaf()` is a bit ugly now, and could probably be done better with type traits as you mentioned in an earlier pull request.

There's definitely lots of things that could be improved here, but at this point I'm just trying to stay on-schedule.