### PR TITLE
Added support for bulk loading

### DIFF
--- a/data_structures/quadtree.hpp
+++ b/data_structures/quadtree.hpp
@@ -29,6 +29,7 @@ namespace spatial {
                         Quadtree<T>& tree, 
                         std::vector<Datum<T>> data
                     );
+                    void populate(Range const idx_range, int const depth);
                     int get_quadrant(Point const p) const;
                     void create_children();
                     bool is_leaf() const;
@@ -130,28 +131,23 @@ namespace spatial {
                     bool empty() { return (pq.empty()); }
             };
 
-            struct Leaf { std::vector<Datum<T>> bucket; };
-
-            // Node Priority Queue Element
-            struct NodePQE {
-                std::unique_ptr<Node> node;
-                coord_t dist;
-            };
-
-            // Datum Priority Queue Element
-            // Datum can be space-intensive, should use a pointer here instead
-            struct DatumPQE {
+            struct ZPair {
                 Datum<T> datum;
-                coord_t dist;
+                code_t code;
             };
             
             std::unique_ptr<Node> root;
             std::vector<std::vector<Datum<T>>> leaves;
 
+            bool _bulk_load(std::vector<Datum<T>> const& data);
+            code_t zorder_hash(Point const p, int const depth) const;
+
         public:
             Quadtree(coord_t x0, coord_t x1, coord_t y0, coord_t y1);
             ~Quadtree();
-            Range build(std::vector<T> const& raw_data);
+            void build(std::vector<T> const& raw_data);
+            void insert(std::vector<T> const& raw_data);
+            void bulk_load(std::vector<T> const& raw_data);
             std::vector<T> query_knn(
                 unsigned const k, coord_t const x, coord_t const y
             ) const;


### PR DESCRIPTION
I did end up doing some bit interleaving, but only to convert from quadtree cell indices -> Z-order codes (which is a lot less work than interleaving two floating point numbers, thankfully). The result is super fast!

Also, because of the way I calculate quadtree leaf indices, I vertically flipped the Z-order curve we build along (aka, it now starts in the southwest quadrant, and ends in the northeast). This doesn't really change anything at a high level, but there were a few parts of the existing code which I had to change to accommodate this.